### PR TITLE
add DejaVu Sans Mono to code font families

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ use yaml_rust::YamlLoader;
 
 const STYLE_HTML: &'static str = r#"<style>
 code {
-    font-family: "SFMono-Regular", Monaco, Menlo, Consolas, "Liberation Mono", monospace;
+    font-family: "SFMono-Regular", "DejaVu Sans Mono", Monaco, Menlo, Consolas, "Liberation Mono", monospace;
     font-size: 12px;
     line-height: 20px;
     white-space: pre-wrap;


### PR DESCRIPTION
Monaco is too foreign to me (and perhaps most Linux users since it's proprietary).